### PR TITLE
Add simple clipboard translator

### DIFF
--- a/Clip Translator Widget/ClipboardWidget.swift
+++ b/Clip Translator Widget/ClipboardWidget.swift
@@ -1,0 +1,54 @@
+import WidgetKit
+import SwiftUI
+import UIKit
+
+struct ClipboardEntry: TimelineEntry {
+    let date: Date
+    let translatedText: String
+}
+
+struct ClipboardProvider: TimelineProvider {
+    func placeholder(in context: Context) -> ClipboardEntry {
+        ClipboardEntry(date: Date(), translatedText: "example")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (ClipboardEntry) -> Void) {
+        let entry = ClipboardEntry(date: Date(), translatedText: ClipboardTranslator().translatedText)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ClipboardEntry>) -> Void) {
+        let translator = ClipboardTranslator()
+        let entry = ClipboardEntry(date: Date(), translatedText: translator.translatedText)
+        let timeline = Timeline(entries: [entry], policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct ClipboardWidgetEntryView: View {
+    var entry: ClipboardProvider.Entry
+
+    var body: some View {
+        Text(entry.translatedText)
+            .padding()
+    }
+}
+
+struct ClipboardWidget: Widget {
+    let kind: String = "ClipboardWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: ClipboardProvider()) { entry in
+            ClipboardWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Clipboard Translator")
+        .description("Displays translation of clipboard text.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+#Preview(as: .systemSmall) {
+    ClipboardWidget()
+} timeline: {
+    ClipboardEntry(date: .now, translatedText: "こんにちは")
+}

--- a/Clip Translator/ContentView.swift
+++ b/Clip Translator/ContentView.swift
@@ -6,14 +6,22 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct ContentView: View {
+    @StateObject private var translator = ClipboardTranslator()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 12) {
+            Text("Clipboard Translation")
+                .font(.headline)
+            Text(translator.translatedText)
+                .multilineTextAlignment(.center)
+                .padding()
+            Button("Refresh") {
+                translator.refresh()
+            }
+            .buttonStyle(.borderedProminent)
         }
         .padding()
     }

--- a/Clip Translator/Translator.swift
+++ b/Clip Translator/Translator.swift
@@ -1,0 +1,42 @@
+import Foundation
+import UIKit
+
+/// Simple offline translator using a small dictionary.
+struct Translator {
+    /// Dictionary containing example translations from English to Japanese.
+    private static let dictionary: [String: String] = [
+        "hello": "こんにちは",
+        "world": "世界",
+        "good": "良い",
+        "morning": "朝",
+        "cat": "猫",
+        "dog": "犬"
+    ]
+
+    /// Translates a phrase. Returns the original text if no translation exists.
+    static func translate(_ text: String) -> String {
+        let lowercased = text.lowercased()
+        if let translated = dictionary[lowercased] {
+            return translated
+        }
+        return text
+    }
+}
+
+/// Helper object that reads clipboard and publishes translated text.
+final class ClipboardTranslator: ObservableObject {
+    @Published var translatedText: String = ""
+
+    init() {
+        refresh()
+    }
+
+    /// Reads the current clipboard string and updates ``translatedText``.
+    func refresh() {
+        if let value = UIPasteboard.general.string, !value.isEmpty {
+            translatedText = Translator.translate(value)
+        } else {
+            translatedText = "(clipboard empty)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Translator` and `ClipboardTranslator` helpers
- show translation in `ContentView`
- provide an example `Widget` implementation

## Testing
- `swift --version`
- `swiftc Clip Translator/Translator.swift -emit-library -o /tmp/libdummy.so` *(fails: no such module 'UIKit')*


------
https://chatgpt.com/codex/tasks/task_e_68556f6581208326adfb04e3c3420aec